### PR TITLE
⚡ Optimize MCP server file I/O to be non-blocking

### DIFF
--- a/packages/spark_cli/lib/src/mcp/spark_mcp_server.dart
+++ b/packages/spark_cli/lib/src/mcp/spark_mcp_server.dart
@@ -334,7 +334,7 @@ McpTool _createPageTool() {
       final filePath = p.join(workDir, 'lib', 'pages', fileName);
 
       final file = File(filePath);
-      if (file.existsSync()) {
+      if (await file.exists()) {
         return McpToolResult(
           content: [McpContent.text('Error: File $filePath already exists.')],
           isError: true,
@@ -394,7 +394,7 @@ McpTool _createEndpointTool() {
       final filePath = p.join(workDir, 'lib', 'endpoints', fileName);
 
       final file = File(filePath);
-      if (file.existsSync()) {
+      if (await file.exists()) {
         return McpToolResult(
           content: [McpContent.text('Error: File $filePath already exists.')],
           isError: true,
@@ -475,7 +475,7 @@ McpTool _createComponentTool() {
       final baseFile = p.join(componentDir, '${snakeName}_base.dart');
 
       final dir = Directory(componentDir);
-      if (dir.existsSync()) {
+      if (await dir.exists()) {
         return McpToolResult(
           content: [
             McpContent.text('Error: Directory $componentDir already exists.'),

--- a/packages/spark_cli/test/spark_mcp_server_test.dart
+++ b/packages/spark_cli/test/spark_mcp_server_test.dart
@@ -41,7 +41,15 @@ Future<Map<String, Object?>> _sendRequest(
 ) async {
   final countBefore = responses.length;
   input.add(jsonEncode(message));
-  await Future<void>.delayed(const Duration(milliseconds: 50));
+
+  // Wait up to 2 seconds for a response
+  for (var i = 0; i < 40; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (responses.length > countBefore) {
+      break;
+    }
+  }
+
   expect(
     responses.length,
     greaterThan(countBefore),


### PR DESCRIPTION
Replaced synchronous file I/O operations with asynchronous ones in `packages/spark_cli/lib/src/mcp/spark_mcp_server.dart` to prevent blocking the event loop. This change affects `_createPageTool`, `_createEndpointTool`, and `_createComponentTool`. Also updated the corresponding test suite `packages/spark_cli/test/spark_mcp_server_test.dart` to handle asynchronous responses more reliably by replacing a fixed delay with a polling loop.

This change is a performance optimization for the MCP server.

Test plan:
- Verified changes with `dart test packages/spark_cli/test/spark_mcp_server_test.dart`.
- Verified no regressions with `dart test packages/spark_cli`.


---
*PR created automatically by Jules for task [8583398192126324734](https://jules.google.com/task/8583398192126324734) started by @kevin-sakemaer*