### PR TITLE
🧪 Test: Improve test coverage for server request extensions

### DIFF
--- a/packages/spark/test/server/request_extensions_test.dart
+++ b/packages/spark/test/server/request_extensions_test.dart
@@ -1,71 +1,101 @@
 @TestOn('vm')
 library;
 
-import 'dart:io';
-
 import 'package:shelf/shelf.dart';
-import 'package:spark_framework/src/server/request_ip_extension.dart';
+import 'package:spark_framework/src/server/request_extensions.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('RequestClientIp', () {
-    test('returns ip from x-forwarded-for header', () {
-      final request = Request(
-        'GET',
-        Uri.parse('http://localhost/'),
-        headers: {'x-forwarded-for': '1.2.3.4, 5.6.7.8'},
-      );
-      expect(request.clientIp, '1.2.3.4');
-    });
-
-    test('returns null if x-forwarded-for is empty', () {
-      final request = Request(
-        'GET',
-        Uri.parse('http://localhost/'),
-        headers: {'x-forwarded-for': ''},
-      );
-      expect(request.clientIp, null);
-    });
-
-    test('returns ip from connection info if header is missing', () {
-      final connectionInfo = _MockHttpConnectionInfo(
-        InternetAddress('9.8.7.6', type: InternetAddressType.IPv4),
-      );
-
-      final request = Request(
-        'GET',
-        Uri.parse('http://localhost/'),
-        context: {'shelf.io.connection_info': connectionInfo},
-      );
-      expect(request.clientIp, '9.8.7.6');
-    });
-
-    test('prioritizes header over connection info', () {
-      final connectionInfo = _MockHttpConnectionInfo(
-        InternetAddress('9.8.7.6', type: InternetAddressType.IPv4),
-      );
-      final request = Request(
-        'GET',
-        Uri.parse('http://localhost/'),
-        headers: {'x-forwarded-for': '1.2.3.4'},
-        context: {'shelf.io.connection_info': connectionInfo},
-      );
-      expect(request.clientIp, '1.2.3.4');
-    });
-
-    test('returns null if both missing', () {
+  group('RequestSet and RequestGet', () {
+    test('can set and get a value of type T', () {
       final request = Request('GET', Uri.parse('http://localhost/'));
-      expect(request.clientIp, null);
+      final newRequest = request.set<String>(() => 'test_value');
+
+      expect(newRequest.get<String>(), 'test_value');
+    });
+
+    test('value is initialized lazily', () {
+      var callCount = 0;
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      final newRequest = request.set<String>(() {
+        callCount++;
+        return 'test_value';
+      });
+
+      expect(callCount, 0); // Not called yet
+      expect(newRequest.get<String>(), 'test_value');
+      expect(callCount, 1); // Called once
+    });
+
+    test('can set and get multiple values of different types', () {
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      final newRequest = request
+          .set<String>(() => 'string_value')
+          .set<int>(() => 42);
+
+      expect(newRequest.get<String>(), 'string_value');
+      expect(newRequest.get<int>(), 42);
+    });
+
+    test('throws StateError when get<T> is called without a provider', () {
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      expect(
+        () => request.get<String>(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('request.get<String>() called with a request context that does not contain a String'),
+          ),
+        ),
+      );
     });
   });
-}
 
-class _MockHttpConnectionInfo implements HttpConnectionInfo {
-  @override
-  final InternetAddress remoteAddress;
+  group('RequestGetPathParameter', () {
+    test('can get an existing path parameter', () {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        context: {
+          'shelf_router/params': {'id': '123'},
+        },
+      );
+      expect(request.getPathParameter('id'), '123');
+    });
 
-  _MockHttpConnectionInfo(this.remoteAddress);
+    test('throws StateError when path parameter is missing', () {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        context: {
+          'shelf_router/params': <String, String>{},
+        },
+      );
+      expect(
+        () => request.getPathParameter('missing_id'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('request.getPathParameter(missing_id) called with a request context that does not contain a value'),
+          ),
+        ),
+      );
+    });
 
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+     test('throws StateError when shelf_router/params context is missing', () {
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      expect(
+        () => request.getPathParameter('missing_id'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('request.getPathParameter(missing_id) called with a request context that does not contain a value'),
+          ),
+        ),
+      );
+    });
+  });
 }

--- a/packages/spark/test/server/request_ip_extension_test.dart
+++ b/packages/spark/test/server/request_ip_extension_test.dart
@@ -1,0 +1,71 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:spark_framework/src/server/request_ip_extension.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestClientIp', () {
+    test('returns ip from x-forwarded-for header', () {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        headers: {'x-forwarded-for': '1.2.3.4, 5.6.7.8'},
+      );
+      expect(request.clientIp, '1.2.3.4');
+    });
+
+    test('returns null if x-forwarded-for is empty', () {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        headers: {'x-forwarded-for': ''},
+      );
+      expect(request.clientIp, null);
+    });
+
+    test('returns ip from connection info if header is missing', () {
+      final connectionInfo = _MockHttpConnectionInfo(
+        InternetAddress('9.8.7.6', type: InternetAddressType.IPv4),
+      );
+
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        context: {'shelf.io.connection_info': connectionInfo},
+      );
+      expect(request.clientIp, '9.8.7.6');
+    });
+
+    test('prioritizes header over connection info', () {
+      final connectionInfo = _MockHttpConnectionInfo(
+        InternetAddress('9.8.7.6', type: InternetAddressType.IPv4),
+      );
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/'),
+        headers: {'x-forwarded-for': '1.2.3.4'},
+        context: {'shelf.io.connection_info': connectionInfo},
+      );
+      expect(request.clientIp, '1.2.3.4');
+    });
+
+    test('returns null if both missing', () {
+      final request = Request('GET', Uri.parse('http://localhost/'));
+      expect(request.clientIp, null);
+    });
+  });
+}
+
+class _MockHttpConnectionInfo implements HttpConnectionInfo {
+  @override
+  final InternetAddress remoteAddress;
+
+  _MockHttpConnectionInfo(this.remoteAddress);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
*   🎯 **What:** The `RequestSet`, `RequestGet`, and `RequestGetPathParameter` extensions in `packages/spark/lib/src/server/request_extensions.dart` were untested.
*   📊 **Coverage:** Added tests for:
    *   Setting and getting values using `set<T>` and `get<T>`.
    *   Lazy initialization of values.
    *   Error handling for missing providers.
    *   Retrieving path parameters using `getPathParameter`.
    *   Error handling for missing path parameters.
*   ✨ **Result:** Increased test coverage and improved test organization by renaming the existing `request_extensions_test.dart` to `request_ip_extension_test.dart` to better reflect its content.

---
*PR created automatically by Jules for task [3846426322940236321](https://jules.google.com/task/3846426322940236321) started by @kevin-sakemaer*