### PR TITLE
🔒 Fix Stored XSS in directory listing

### DIFF
--- a/packages/spark/lib/src/server/static_handler.dart
+++ b/packages/spark/lib/src/server/static_handler.dart
@@ -1,7 +1,9 @@
 /// Static file handler for serving compiled assets.
 library;
 
+import 'dart:convert';
 import 'dart:io';
+
 import 'package:shelf/shelf.dart';
 
 /// MIME type mappings for common file extensions.
@@ -206,10 +208,15 @@ Future<Response> _serveFile(
 
 /// Lists directory contents as HTML.
 Response _listDirectory(Directory dir, String requestPath) {
+  const htmlEscape = HtmlEscape();
+  final safeRequestPath = htmlEscape.convert(requestPath);
+
   final buffer = StringBuffer();
   buffer.writeln('<!DOCTYPE html>');
-  buffer.writeln('<html><head><title>Index of /$requestPath</title></head>');
-  buffer.writeln('<body><h1>Index of /$requestPath</h1><ul>');
+  buffer.writeln(
+    '<html><head><title>Index of /$safeRequestPath</title></head>',
+  );
+  buffer.writeln('<body><h1>Index of /$safeRequestPath</h1><ul>');
 
   if (requestPath.isNotEmpty) {
     buffer.writeln('<li><a href="../">..</a></li>');
@@ -218,8 +225,11 @@ Response _listDirectory(Directory dir, String requestPath) {
   for (final entity in dir.listSync()) {
     final name = entity.path.split('/').last;
     final isDir = entity is Directory;
+    final safeName = htmlEscape.convert(name);
+    final url = Uri.encodeComponent(name);
+
     buffer.writeln(
-      '<li><a href="$name${isDir ? '/' : ''}">$name${isDir ? '/' : ''}</a></li>',
+      '<li><a href="$url${isDir ? '/' : ''}">$safeName${isDir ? '/' : ''}</a></li>',
     );
   }
 

--- a/packages/spark/test/static_handler_xss_test.dart
+++ b/packages/spark/test/static_handler_xss_test.dart
@@ -1,0 +1,74 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:spark_framework/src/server/static_handler.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('static_handler_xss_test_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Request request(String path) {
+    return Request('GET', Uri.parse('http://localhost/$path'));
+  }
+
+  test('escapes special characters in directory listing', () async {
+    final subDirName = 'special&chars';
+    final fileName = 'file&name.txt';
+
+    final subDir = Directory('${tempDir.path}/$subDirName');
+    await subDir.create();
+
+    final file = File('${subDir.path}/$fileName');
+    await file.writeAsString('content');
+
+    final handler = createStaticHandler(
+      tempDir.path,
+      config: StaticHandlerConfig(path: tempDir.path, listDirectories: true),
+    );
+
+    // Request with unencoded '&' as it is valid in path segments
+    final response = await handler(request('special&chars'));
+
+    expect(
+      response.statusCode,
+      200,
+      reason: 'Should find directory "special&chars"',
+    );
+    final body = await response.readAsString();
+
+    // Verify title contains escaped path
+    expect(
+      body,
+      contains('Index of /special&amp;chars'),
+      reason: 'Title should be escaped',
+    );
+
+    // Verify header contains escaped path
+    expect(
+      body,
+      contains('<h1>Index of /special&amp;chars</h1>'),
+      reason: 'Header should be escaped',
+    );
+
+    // Verify file list contains escaped filename
+    // <a href="...">file&amp;name.txt</a>
+    expect(
+      body,
+      contains('>file&amp;name.txt</a>'),
+      reason: 'File name in list should be escaped',
+    );
+  });
+}


### PR DESCRIPTION
This PR fixes a stored Cross-Site Scripting (XSS) vulnerability in the `static_handler.dart` directory listing feature. Previously, `requestPath` and file names were interpolated directly into the HTML response, allowing malicious filenames or request paths to inject arbitrary HTML/JS.

Changes:
- Use `HtmlEscape` to sanitize `requestPath` in `<title>` and `<h1>`.
- Use `HtmlEscape` to sanitize file names in the visible link text.
- Use `Uri.encodeComponent` to sanitize file names in the `href` attribute, ensuring valid URLs and preventing attribute injection.
- Added `packages/spark/test/static_handler_xss_test.dart` to reproduce and verify the fix.

---
*PR created automatically by Jules for task [16218313836966382612](https://jules.google.com/task/16218313836966382612) started by @kevin-sakemaer*