### PR TITLE
Add CI workflows for spark_css, spark_html_dsl, and spark_vdom

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,15 +33,36 @@ jobs:
     outputs:
       spark: ${{ steps.filter.outputs.spark }}
       spark_cli: ${{ steps.filter.outputs.spark_cli }}
+      spark_css: ${{ steps.filter.outputs.spark_css }}
       spark_generator: ${{ steps.filter.outputs.spark_generator }}
+      spark_html_dsl: ${{ steps.filter.outputs.spark_html_dsl }}
+      spark_vdom: ${{ steps.filter.outputs.spark_vdom }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
+            spark_css:
+              - 'packages/spark_css/**'
+              - 'pubspec.yaml'
+              - '.github/workflows/ci.yaml'
+            spark_html_dsl:
+              - 'packages/spark_html_dsl/**'
+              - 'packages/spark_web/**'
+              - 'pubspec.yaml'
+              - '.github/workflows/ci.yaml'
+            spark_vdom:
+              - 'packages/spark_vdom/**'
+              - 'packages/spark_html_dsl/**'
+              - 'packages/spark_web/**'
+              - 'pubspec.yaml'
+              - '.github/workflows/ci.yaml'
             spark:
               - 'packages/spark/**'
+              - 'packages/spark_css/**'
+              - 'packages/spark_html_dsl/**'
+              - 'packages/spark_vdom/**'
               - 'packages/spark_web/**'
               - 'pubspec.yaml'
               - '.github/workflows/ci.yaml'
@@ -52,6 +73,9 @@ jobs:
             spark_generator:
               - 'packages/spark_generator/**'
               - 'packages/spark/**'
+              - 'packages/spark_css/**'
+              - 'packages/spark_html_dsl/**'
+              - 'packages/spark_vdom/**'
               - 'packages/spark_web/**'
               - 'pubspec.yaml'
               - '.github/workflows/ci.yaml'
@@ -76,6 +100,69 @@ jobs:
       - name: Run tests
         run: |
           cd packages/spark
+          dart test
+          dart test -p chrome
+
+  test_spark_css:
+    needs: changes
+    if: ${{ needs.changes.outputs.spark_css == 'true' }}
+    name: Test Spark CSS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: "3.10.7"
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: |
+          cd packages/spark_css
+          dart test
+
+  test_spark_html_dsl:
+    needs: changes
+    if: ${{ needs.changes.outputs.spark_html_dsl == 'true' }}
+    name: Test Spark HTML DSL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: "3.10.7"
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: |
+          cd packages/spark_html_dsl
+          dart test
+
+  test_spark_vdom:
+    needs: changes
+    if: ${{ needs.changes.outputs.spark_vdom == 'true' }}
+    name: Test Spark VDOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: "3.10.7"
+
+      - uses: browser-actions/setup-chrome@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: |
+          cd packages/spark_vdom
           dart test
           dart test -p chrome
 


### PR DESCRIPTION
## Summary
This PR extends the CI/CD pipeline to include automated testing for three new Spark packages: `spark_css`, `spark_html_dsl`, and `spark_vdom`. These packages are now tracked with path-based filtering to run tests only when relevant files change.

## Key Changes
- **Added path filters** for three new packages (`spark_css`, `spark_html_dsl`, `spark_vdom`) to detect when changes require testing
- **Updated existing filters** for `spark` and `spark_generator` to include dependencies on the new packages, ensuring tests run when dependencies change
- **Added three new test jobs**:
  - `test_spark_css`: Runs Dart tests for the CSS package
  - `test_spark_html_dsl`: Runs Dart tests for the HTML DSL package
  - `test_spark_vdom`: Runs Dart tests for the VDOM package with both standard and Chrome browser tests
- **Configured dependency tracking** so that changes to `spark_css`, `spark_html_dsl`, and `spark_vdom` trigger tests in dependent packages (`spark` and `spark_generator`)

## Implementation Details
- All new test jobs follow the existing pattern with Dart 3.10.7 SDK
- The `spark_vdom` job includes Chrome browser testing via `browser-actions/setup-chrome@v1`
- Path filters account for package interdependencies (e.g., `spark_vdom` depends on `spark_html_dsl` and `spark_web`)
- Tests only run when relevant files change, optimizing CI resource usage

https://claude.ai/code/session_01YBBHRKyAojmVtF2nNg4zc8