### PR TITLE
Add typed CssBoxShadow support to spark_css

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_box_shadow.dart
+++ b/packages/spark_css/lib/src/css_types/css_box_shadow.dart
@@ -1,0 +1,114 @@
+import 'css_color.dart';
+import 'css_length.dart';
+import 'css_value.dart';
+
+/// CSS box-shadow value type.
+sealed class CssBoxShadow implements CssValue {
+  const CssBoxShadow._();
+
+  /// No shadow.
+  static const CssBoxShadow none = _CssBoxShadowKeyword('none');
+
+  /// Creates a single box-shadow value.
+  factory CssBoxShadow({
+    required CssLength x,
+    required CssLength y,
+    CssLength? blur,
+    CssLength? spread,
+    CssColor? color,
+    bool? inset,
+  }) = _CssBoxShadowSingle;
+
+  /// Creates a list of box-shadow values.
+  factory CssBoxShadow.multiple(List<CssBoxShadow> shadows) =
+      _CssBoxShadowMultiple;
+
+  /// CSS variable reference.
+  factory CssBoxShadow.variable(String varName) = _CssBoxShadowVariable;
+
+  /// Raw CSS value escape hatch.
+  factory CssBoxShadow.raw(String value) = _CssBoxShadowRaw;
+
+  /// Global keyword (inherit, initial, unset, revert).
+  factory CssBoxShadow.global(CssGlobal global) = _CssBoxShadowGlobal;
+}
+
+final class _CssBoxShadowKeyword extends CssBoxShadow {
+  final String keyword;
+  const _CssBoxShadowKeyword(this.keyword) : super._();
+
+  @override
+  String toCss() => keyword;
+}
+
+final class _CssBoxShadowSingle extends CssBoxShadow {
+  final CssLength x;
+  final CssLength y;
+  final CssLength? blur;
+  final CssLength? spread;
+  final CssColor? color;
+  final bool inset;
+
+  const _CssBoxShadowSingle({
+    required this.x,
+    required this.y,
+    this.blur,
+    this.spread,
+    this.color,
+    bool? inset,
+  }) : inset = inset ?? false,
+       super._();
+
+  @override
+  String toCss() {
+    final parts = <String>[];
+    if (inset) parts.add('inset');
+    parts.add(x.toCss());
+    parts.add(y.toCss());
+    if (blur != null) {
+      parts.add(blur!.toCss());
+    }
+    if (spread != null) {
+      if (blur == null) {
+        parts.add('0'); // spread requires blur to be present
+      }
+      parts.add(spread!.toCss());
+    }
+    if (color != null) {
+      parts.add(color!.toCss());
+    }
+    return parts.join(' ');
+  }
+}
+
+final class _CssBoxShadowMultiple extends CssBoxShadow {
+  final List<CssBoxShadow> shadows;
+  const _CssBoxShadowMultiple(this.shadows) : super._();
+
+  @override
+  String toCss() => shadows.map((s) => s.toCss()).join(', ');
+}
+
+final class _CssBoxShadowVariable extends CssBoxShadow {
+  final String varName;
+  const _CssBoxShadowVariable(this.varName) : super._();
+
+  @override
+  String toCss() => 'var(--$varName)';
+}
+
+final class _CssBoxShadowRaw extends CssBoxShadow {
+  final String value;
+  const _CssBoxShadowRaw(this.value) : super._();
+
+  @override
+  String toCss() => value;
+}
+
+final class _CssBoxShadowGlobal extends CssBoxShadow {
+  final CssGlobal global;
+  const _CssBoxShadowGlobal(this.global) : super._();
+
+  @override
+  String toCss() => global.toCss();
+}

--- a/packages/spark_css/test/css_box_shadow_test.dart
+++ b/packages/spark_css/test/css_box_shadow_test.dart
@@ -1,0 +1,122 @@
+import 'package:spark_css/src/css_types/css_box_shadow.dart';
+import 'package:spark_css/src/css_types/css_color.dart';
+import 'package:spark_css/src/css_types/css_length.dart';
+import 'package:spark_css/src/css_types/css_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CssBoxShadow', () {
+    test('none outputs correct CSS', () {
+      expect(CssBoxShadow.none.toCss(), equals('none'));
+    });
+
+    test('single shadow with required params outputs correct CSS', () {
+      expect(
+        CssBoxShadow(x: CssLength.px(1), y: CssLength.px(2)).toCss(),
+        equals('1px 2px'),
+      );
+    });
+
+    test('single shadow with color outputs correct CSS', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          color: CssColor.black,
+        ).toCss(),
+        equals('1px 2px black'),
+      );
+    });
+
+    test('single shadow with blur outputs correct CSS', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          blur: CssLength.px(3),
+        ).toCss(),
+        equals('1px 2px 3px'),
+      );
+    });
+
+    test('single shadow with spread outputs correct CSS (implies blur)', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          spread: CssLength.px(4),
+        ).toCss(),
+        equals('1px 2px 0 4px'),
+      );
+    });
+
+    test('single shadow with blur and spread outputs correct CSS', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          blur: CssLength.px(3),
+          spread: CssLength.px(4),
+        ).toCss(),
+        equals('1px 2px 3px 4px'),
+      );
+    });
+
+    test('single shadow with inset outputs correct CSS', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          inset: true,
+        ).toCss(),
+        equals('inset 1px 2px'),
+      );
+    });
+
+    test('full single shadow outputs correct CSS', () {
+      expect(
+        CssBoxShadow(
+          x: CssLength.px(1),
+          y: CssLength.px(2),
+          blur: CssLength.px(3),
+          spread: CssLength.px(4),
+          color: CssColor.rgba(0, 0, 0, 0.5),
+          inset: true,
+        ).toCss(),
+        equals('inset 1px 2px 3px 4px rgba(0, 0, 0, 0.5)'),
+      );
+    });
+
+    test('multiple shadows output correct CSS', () {
+      expect(
+        CssBoxShadow.multiple([
+          CssBoxShadow(x: CssLength.px(1), y: CssLength.px(1)),
+          CssBoxShadow(
+            x: CssLength.px(2),
+            y: CssLength.px(2),
+            color: CssColor.red,
+          ),
+        ]).toCss(),
+        equals('1px 1px, 2px 2px red'),
+      );
+    });
+
+    test('variable outputs correct CSS', () {
+      expect(
+        CssBoxShadow.variable('shadow-md').toCss(),
+        equals('var(--shadow-md)'),
+      );
+    });
+
+    test('raw outputs correct CSS', () {
+      expect(
+        CssBoxShadow.raw('5px 5px 10px #888888').toCss(),
+        equals('5px 5px 10px #888888'),
+      );
+    });
+
+    test('global outputs correct CSS', () {
+      expect(CssBoxShadow.global(CssGlobal.inherit).toCss(), equals('inherit'));
+    });
+  });
+}


### PR DESCRIPTION
Implemented `CssBoxShadow` in `spark_css` package to support typed box-shadow values, including single and multiple shadows, and standard CSS keywords. Verified with unit tests covering various combinations and edge cases.

---
*PR created automatically by Jules for task [12963353540145713458](https://jules.google.com/task/12963353540145713458) started by @kevin-sakemaer*