### PR TITLE
feat(spark_css): add typed CssTransform and CssAngle support

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_transform.dart
+++ b/packages/spark_css/lib/src/css_types/css_transform.dart
@@ -85,14 +85,8 @@ sealed class CssTransform implements CssValue {
   factory CssTransform.skew(CssAngle x, [CssAngle? y]) = _CssTransformSkew;
 
   /// `matrix` function.
-  factory CssTransform.matrix(
-    num a,
-    num b,
-    num c,
-    num d,
-    num tx,
-    num ty,
-  ) = _CssTransformMatrix;
+  factory CssTransform.matrix(num a, num b, num c, num d, num tx, num ty) =
+      _CssTransformMatrix;
 
   /// Multiple transforms.
   factory CssTransform.list(List<CssTransform> transforms) = _CssTransformList;
@@ -215,14 +209,8 @@ final class _CssTransformSkew extends CssTransform {
 
 final class _CssTransformMatrix extends CssTransform {
   final num a, b, c, d, tx, ty;
-  const _CssTransformMatrix(
-    this.a,
-    this.b,
-    this.c,
-    this.d,
-    this.tx,
-    this.ty,
-  ) : super._();
+  const _CssTransformMatrix(this.a, this.b, this.c, this.d, this.tx, this.ty)
+    : super._();
 
   @override
   String toCss() => 'matrix($a, $b, $c, $d, $tx, $ty)';

--- a/packages/spark_css/test/css_transform_test.dart
+++ b/packages/spark_css/test/css_transform_test.dart
@@ -30,16 +30,28 @@ void main() {
     });
 
     test('translateX', () {
-      expect(CssTransform.translateX(CssLength.px(10)).toCss(), 'translateX(10px)');
-      expect(CssTransform.translateX(CssLength.percent(50)).toCss(), 'translateX(50%)');
+      expect(
+        CssTransform.translateX(CssLength.px(10)).toCss(),
+        'translateX(10px)',
+      );
+      expect(
+        CssTransform.translateX(CssLength.percent(50)).toCss(),
+        'translateX(50%)',
+      );
     });
 
     test('translateY', () {
-      expect(CssTransform.translateY(CssLength.px(20)).toCss(), 'translateY(20px)');
+      expect(
+        CssTransform.translateY(CssLength.px(20)).toCss(),
+        'translateY(20px)',
+      );
     });
 
     test('translate', () {
-      expect(CssTransform.translate(CssLength.px(10)).toCss(), 'translate(10px)');
+      expect(
+        CssTransform.translate(CssLength.px(10)).toCss(),
+        'translate(10px)',
+      );
       expect(
         CssTransform.translate(CssLength.px(10), CssLength.px(20)).toCss(),
         'translate(10px, 20px)',
@@ -98,7 +110,10 @@ void main() {
     });
 
     test('variable', () {
-      expect(CssTransform.variable('transform-var').toCss(), 'var(--transform-var)');
+      expect(
+        CssTransform.variable('transform-var').toCss(),
+        'var(--transform-var)',
+      );
     });
 
     test('raw', () {


### PR DESCRIPTION
This PR introduces typed support for CSS `transform` properties in the `spark_css` package.

Key changes:
- Created `packages/spark_css/lib/src/css_types/css_transform.dart`.
- Defined `CssAngle` sealed class with factory constructors for `deg`, `rad`, `grad`, and `turn`.
- Defined `CssTransform` sealed class implementing `CssValue` with factory constructors for standard CSS transform functions:
  - `translateX`, `translateY`, `translate`
  - `scaleX`, `scaleY`, `scale`
  - `rotate`
  - `skewX`, `skewY`, `skew`
  - `matrix`
  - `list` (for multiple transforms)
  - `variable`, `raw`, `global`
- Added `packages/spark_css/test/css_transform_test.dart` to verify correct CSS string generation.

This implementation allows for type-safe construction of complex transform chains.

---
*PR created automatically by Jules for task [8867289310295869322](https://jules.google.com/task/8867289310295869322) started by @kevin-sakemaer*