### PR TITLE
feat(spark_css): add typed CssBackgroundPosition

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_background_position.dart
+++ b/packages/spark_css/lib/src/css_types/css_background_position.dart
@@ -1,0 +1,104 @@
+import 'css_value.dart';
+
+/// CSS background-position property values.
+sealed class CssBackgroundPosition implements CssValue {
+  const CssBackgroundPosition._();
+
+  // Keyword values
+  static const CssBackgroundPosition left = _CssBackgroundPositionKeyword(
+    'left',
+  );
+  static const CssBackgroundPosition center = _CssBackgroundPositionKeyword(
+    'center',
+  );
+  static const CssBackgroundPosition right = _CssBackgroundPositionKeyword(
+    'right',
+  );
+  static const CssBackgroundPosition top = _CssBackgroundPositionKeyword('top');
+  static const CssBackgroundPosition bottom = _CssBackgroundPositionKeyword(
+    'bottom',
+  );
+
+  /// Creates a position from one to four values (keywords or lengths).
+  ///
+  /// Example:
+  /// ```dart
+  /// CssBackgroundPosition.parts([CssBackgroundPosition.left, CssLength.px(20)])
+  /// // Output: left 20px
+  /// ```
+  factory CssBackgroundPosition.parts(List<CssValue> values) =
+      _CssBackgroundPositionParts;
+
+  /// Multiple background positions (comma-separated).
+  ///
+  /// Example:
+  /// ```dart
+  /// CssBackgroundPosition.multiple([
+  ///   CssBackgroundPosition.parts([CssBackgroundPosition.left]),
+  ///   CssBackgroundPosition.parts([CssBackgroundPosition.right]),
+  /// ])
+  /// // Output: left, right
+  /// ```
+  factory CssBackgroundPosition.multiple(
+    List<CssBackgroundPosition> positions,
+  ) = _CssBackgroundPositionMultiple;
+
+  /// CSS variable reference.
+  factory CssBackgroundPosition.variable(String varName) =
+      _CssBackgroundPositionVariable;
+
+  /// Raw CSS value escape hatch.
+  factory CssBackgroundPosition.raw(String value) = _CssBackgroundPositionRaw;
+
+  /// Global keyword (inherit, initial, unset, revert).
+  factory CssBackgroundPosition.global(CssGlobal global) =
+      _CssBackgroundPositionGlobal;
+}
+
+final class _CssBackgroundPositionKeyword extends CssBackgroundPosition {
+  final String keyword;
+  const _CssBackgroundPositionKeyword(this.keyword) : super._();
+
+  @override
+  String toCss() => keyword;
+}
+
+final class _CssBackgroundPositionParts extends CssBackgroundPosition {
+  final List<CssValue> values;
+  const _CssBackgroundPositionParts(this.values) : super._();
+
+  @override
+  String toCss() => values.map((v) => v.toCss()).join(' ');
+}
+
+final class _CssBackgroundPositionMultiple extends CssBackgroundPosition {
+  final List<CssBackgroundPosition> positions;
+  const _CssBackgroundPositionMultiple(this.positions) : super._();
+
+  @override
+  String toCss() => positions.map((p) => p.toCss()).join(', ');
+}
+
+final class _CssBackgroundPositionVariable extends CssBackgroundPosition {
+  final String varName;
+  const _CssBackgroundPositionVariable(this.varName) : super._();
+
+  @override
+  String toCss() => 'var(--$varName)';
+}
+
+final class _CssBackgroundPositionRaw extends CssBackgroundPosition {
+  final String value;
+  const _CssBackgroundPositionRaw(this.value) : super._();
+
+  @override
+  String toCss() => value;
+}
+
+final class _CssBackgroundPositionGlobal extends CssBackgroundPosition {
+  final CssGlobal global;
+  const _CssBackgroundPositionGlobal(this.global) : super._();
+
+  @override
+  String toCss() => global.toCss();
+}

--- a/packages/spark_css/test/css_background_position_test.dart
+++ b/packages/spark_css/test/css_background_position_test.dart
@@ -1,0 +1,108 @@
+import 'package:spark_css/spark_css.dart';
+import 'package:spark_css/src/css_types/css_background_position.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CssBackgroundPosition', () {
+    test('keywords output correct CSS', () {
+      expect(CssBackgroundPosition.left.toCss(), equals('left'));
+      expect(CssBackgroundPosition.center.toCss(), equals('center'));
+      expect(CssBackgroundPosition.right.toCss(), equals('right'));
+      expect(CssBackgroundPosition.top.toCss(), equals('top'));
+      expect(CssBackgroundPosition.bottom.toCss(), equals('bottom'));
+    });
+
+    test('parts outputs correct CSS with lengths and keywords', () {
+      // 1 value
+      expect(
+        CssBackgroundPosition.parts([CssBackgroundPosition.left]).toCss(),
+        equals('left'),
+      );
+
+      // 2 values (keyword + length)
+      expect(
+        CssBackgroundPosition.parts([
+          CssBackgroundPosition.left,
+          CssLength.px(20),
+        ]).toCss(),
+        equals('left 20px'),
+      );
+
+      // 2 values (length + length)
+      expect(
+        CssBackgroundPosition.parts([
+          CssLength.percent(50),
+          CssLength.percent(50),
+        ]).toCss(),
+        equals('50% 50%'),
+      );
+
+      // 3 values
+      expect(
+        CssBackgroundPosition.parts([
+          CssBackgroundPosition.left,
+          CssLength.px(20),
+          CssBackgroundPosition.top,
+        ]).toCss(),
+        equals('left 20px top'),
+      );
+
+      // 4 values
+      expect(
+        CssBackgroundPosition.parts([
+          CssBackgroundPosition.left,
+          CssLength.px(20),
+          CssBackgroundPosition.top,
+          CssLength.px(10),
+        ]).toCss(),
+        equals('left 20px top 10px'),
+      );
+    });
+
+    test('multiple outputs correct CSS', () {
+      expect(
+        CssBackgroundPosition.multiple([
+          CssBackgroundPosition.parts([CssBackgroundPosition.left]),
+          CssBackgroundPosition.parts([CssBackgroundPosition.right]),
+        ]).toCss(),
+        equals('left, right'),
+      );
+
+      expect(
+        CssBackgroundPosition.multiple([
+          CssBackgroundPosition.parts([
+            CssBackgroundPosition.left,
+            CssLength.px(20),
+          ]),
+          CssBackgroundPosition.center,
+        ]).toCss(),
+        equals('left 20px, center'),
+      );
+    });
+
+    test('variable outputs correct CSS', () {
+      expect(
+        CssBackgroundPosition.variable('bg-pos').toCss(),
+        equals('var(--bg-pos)'),
+      );
+    });
+
+    test('raw outputs value as-is', () {
+      expect(
+        CssBackgroundPosition.raw('left 20px').toCss(),
+        equals('left 20px'),
+      );
+    });
+
+    test('global outputs correct CSS', () {
+      expect(
+        CssBackgroundPosition.global(CssGlobal.inherit).toCss(),
+        equals('inherit'),
+      );
+      expect(
+        CssBackgroundPosition.global(CssGlobal.initial).toCss(),
+        equals('initial'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a typed `CssBackgroundPosition` class to the `spark_css` package.
It supports:
- Standard keywords (`left`, `center`, `right`, `top`, `bottom`).
- One-to-four value syntax via `CssBackgroundPosition.parts(List<CssValue>)`.
- Multiple background positions via `CssBackgroundPosition.multiple(List<CssBackgroundPosition>)`.
- CSS variables, raw strings, and global keywords.
- Comprehensive tests ensuring correct CSS string generation.


---
*PR created automatically by Jules for task [1151674362161964337](https://jules.google.com/task/1151674362161964337) started by @kevin-sakemaer*