### PR TITLE
Add CssBackgroundAttachment type

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_background_attachment.dart
+++ b/packages/spark_css/lib/src/css_types/css_background_attachment.dart
@@ -1,0 +1,74 @@
+import 'css_value.dart';
+
+/// CSS background-attachment property values.
+sealed class CssBackgroundAttachment implements CssValue {
+  const CssBackgroundAttachment._();
+
+  // Keyword values
+  static const CssBackgroundAttachment scroll = _CssBackgroundAttachmentKeyword(
+    'scroll',
+  );
+  static const CssBackgroundAttachment fixed = _CssBackgroundAttachmentKeyword(
+    'fixed',
+  );
+  static const CssBackgroundAttachment local = _CssBackgroundAttachmentKeyword(
+    'local',
+  );
+
+  /// Multiple background attachments.
+  factory CssBackgroundAttachment.multiple(
+    List<CssBackgroundAttachment> attachments,
+  ) = _CssBackgroundAttachmentMultiple;
+
+  /// CSS variable reference.
+  factory CssBackgroundAttachment.variable(String varName) =
+      _CssBackgroundAttachmentVariable;
+
+  /// Raw CSS value escape hatch.
+  factory CssBackgroundAttachment.raw(String value) =
+      _CssBackgroundAttachmentRaw;
+
+  /// Global keyword (inherit, initial, unset, revert).
+  factory CssBackgroundAttachment.global(CssGlobal global) =
+      _CssBackgroundAttachmentGlobal;
+}
+
+final class _CssBackgroundAttachmentKeyword extends CssBackgroundAttachment {
+  final String keyword;
+  const _CssBackgroundAttachmentKeyword(this.keyword) : super._();
+
+  @override
+  String toCss() => keyword;
+}
+
+final class _CssBackgroundAttachmentMultiple extends CssBackgroundAttachment {
+  final List<CssBackgroundAttachment> attachments;
+  const _CssBackgroundAttachmentMultiple(this.attachments) : super._();
+
+  @override
+  String toCss() => attachments.map((a) => a.toCss()).join(', ');
+}
+
+final class _CssBackgroundAttachmentVariable extends CssBackgroundAttachment {
+  final String varName;
+  const _CssBackgroundAttachmentVariable(this.varName) : super._();
+
+  @override
+  String toCss() => 'var(--$varName)';
+}
+
+final class _CssBackgroundAttachmentRaw extends CssBackgroundAttachment {
+  final String value;
+  const _CssBackgroundAttachmentRaw(this.value) : super._();
+
+  @override
+  String toCss() => value;
+}
+
+final class _CssBackgroundAttachmentGlobal extends CssBackgroundAttachment {
+  final CssGlobal global;
+  const _CssBackgroundAttachmentGlobal(this.global) : super._();
+
+  @override
+  String toCss() => global.toCss();
+}

--- a/packages/spark_css/test/css_background_attachment_test.dart
+++ b/packages/spark_css/test/css_background_attachment_test.dart
@@ -1,0 +1,71 @@
+import 'package:spark_css/src/css_types/css_background_attachment.dart';
+import 'package:spark_css/src/css_types/css_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CssBackgroundAttachment', () {
+    test('scroll keyword outputs correct CSS', () {
+      expect(CssBackgroundAttachment.scroll.toCss(), equals('scroll'));
+    });
+
+    test('fixed keyword outputs correct CSS', () {
+      expect(CssBackgroundAttachment.fixed.toCss(), equals('fixed'));
+    });
+
+    test('local keyword outputs correct CSS', () {
+      expect(CssBackgroundAttachment.local.toCss(), equals('local'));
+    });
+
+    test('multiple values output comma-separated string', () {
+      expect(
+        CssBackgroundAttachment.multiple([
+          CssBackgroundAttachment.scroll,
+          CssBackgroundAttachment.fixed,
+        ]).toCss(),
+        equals('scroll, fixed'),
+      );
+    });
+
+    test('variable outputs correct CSS', () {
+      expect(
+        CssBackgroundAttachment.variable('bg-attachment').toCss(),
+        equals('var(--bg-attachment)'),
+      );
+    });
+
+    test('raw value outputs as-is', () {
+      expect(
+        CssBackgroundAttachment.raw('scroll, fixed').toCss(),
+        equals('scroll, fixed'),
+      );
+    });
+
+    test('global inherit outputs correct CSS', () {
+      expect(
+        CssBackgroundAttachment.global(CssGlobal.inherit).toCss(),
+        equals('inherit'),
+      );
+    });
+
+    test('global initial outputs correct CSS', () {
+      expect(
+        CssBackgroundAttachment.global(CssGlobal.initial).toCss(),
+        equals('initial'),
+      );
+    });
+
+    test('global unset outputs correct CSS', () {
+      expect(
+        CssBackgroundAttachment.global(CssGlobal.unset).toCss(),
+        equals('unset'),
+      );
+    });
+
+    test('global revert outputs correct CSS', () {
+      expect(
+        CssBackgroundAttachment.global(CssGlobal.revert).toCss(),
+        equals('revert'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Added `CssBackgroundAttachment` implementation and tests to `spark_css` package.
- Created `packages/spark_css/lib/src/css_types/css_background_attachment.dart`
- Created `packages/spark_css/test/css_background_attachment_test.dart`


---
*PR created automatically by Jules for task [9635849962137873294](https://jules.google.com/task/9635849962137873294) started by @kevin-sakemaer*