### PR TITLE
feat(spark_css): add CssBackgroundSize type

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_background_size.dart
+++ b/packages/spark_css/lib/src/css_types/css_background_size.dart
@@ -25,7 +25,8 @@ sealed class CssBackgroundSize implements CssValue {
       _CssBackgroundSizeMultiple;
 
   /// CSS variable reference.
-  factory CssBackgroundSize.variable(String varName) = _CssBackgroundSizeVariable;
+  factory CssBackgroundSize.variable(String varName) =
+      _CssBackgroundSizeVariable;
 
   /// Raw CSS value escape hatch.
   factory CssBackgroundSize.raw(String value) = _CssBackgroundSizeRaw;

--- a/packages/spark_css/test/css_background_size_test.dart
+++ b/packages/spark_css/test/css_background_size_test.dart
@@ -16,18 +16,12 @@ void main() {
         CssBackgroundSize.size(CssLength.percent(50)).toCss(),
         equals('50%'),
       );
-      expect(
-        CssBackgroundSize.size(CssLength.auto).toCss(),
-        equals('auto'),
-      );
+      expect(CssBackgroundSize.size(CssLength.auto).toCss(), equals('auto'));
     });
 
     test('size factory outputs correct CSS with two values', () {
       expect(
-        CssBackgroundSize.size(
-          CssLength.percent(50),
-          CssLength.auto,
-        ).toCss(),
+        CssBackgroundSize.size(CssLength.percent(50), CssLength.auto).toCss(),
         equals('50% auto'),
       );
       expect(
@@ -65,10 +59,7 @@ void main() {
     });
 
     test('raw outputs value as-is', () {
-      expect(
-        CssBackgroundSize.raw('100% 100%').toCss(),
-        equals('100% 100%'),
-      );
+      expect(CssBackgroundSize.raw('100% 100%').toCss(), equals('100% 100%'));
     });
 
     test('global outputs correct CSS', () {


### PR DESCRIPTION
Implemented `CssBackgroundSize` in `packages/spark_css` to provide a typed interface for the `background-size` CSS property.

Key changes:
- Created `packages/spark_css/lib/src/css_types/css_background_size.dart`.
- Created `packages/spark_css/test/css_background_size_test.dart`.
- Validated implementation with unit tests covering all factories and keywords.

---
*PR created automatically by Jules for task [8501197408068410118](https://jules.google.com/task/8501197408068410118) started by @kevin-sakemaer*