### PR TITLE
feat(spark_css): add CssBackgroundClip type

### DIFF
--- a/packages/spark_css/lib/src/css_types/css_background_clip.dart
+++ b/packages/spark_css/lib/src/css_types/css_background_clip.dart
@@ -5,22 +5,30 @@ sealed class CssBackgroundClip implements CssValue {
   const CssBackgroundClip._();
 
   /// The background extends to the outside edge of the border.
-  static const CssBackgroundClip borderBox = _CssBackgroundClipKeyword('border-box');
+  static const CssBackgroundClip borderBox = _CssBackgroundClipKeyword(
+    'border-box',
+  );
 
   /// The background extends to the outside edge of the padding.
-  static const CssBackgroundClip paddingBox = _CssBackgroundClipKeyword('padding-box');
+  static const CssBackgroundClip paddingBox = _CssBackgroundClipKeyword(
+    'padding-box',
+  );
 
   /// The background extends to the outside edge of the content.
-  static const CssBackgroundClip contentBox = _CssBackgroundClipKeyword('content-box');
+  static const CssBackgroundClip contentBox = _CssBackgroundClipKeyword(
+    'content-box',
+  );
 
   /// The background is clipped to the foreground text.
   static const CssBackgroundClip text = _CssBackgroundClipKeyword('text');
 
   /// Multiple background-clip values for multiple background images.
-  factory CssBackgroundClip.multiple(List<CssBackgroundClip> values) = _CssBackgroundClipMultiple;
+  factory CssBackgroundClip.multiple(List<CssBackgroundClip> values) =
+      _CssBackgroundClipMultiple;
 
   /// CSS variable reference.
-  factory CssBackgroundClip.variable(String varName) = _CssBackgroundClipVariable;
+  factory CssBackgroundClip.variable(String varName) =
+      _CssBackgroundClipVariable;
 
   /// Raw CSS value escape hatch.
   factory CssBackgroundClip.raw(String value) = _CssBackgroundClipRaw;

--- a/packages/spark_css/test/css_background_clip_test.dart
+++ b/packages/spark_css/test/css_background_clip_test.dart
@@ -33,7 +33,10 @@ void main() {
       expect(CssBackgroundClip.global(CssGlobal.initial).toCss(), 'initial');
       expect(CssBackgroundClip.global(CssGlobal.unset).toCss(), 'unset');
       expect(CssBackgroundClip.global(CssGlobal.revert).toCss(), 'revert');
-      expect(CssBackgroundClip.global(CssGlobal.revertLayer).toCss(), 'revert-layer');
+      expect(
+        CssBackgroundClip.global(CssGlobal.revertLayer).toCss(),
+        'revert-layer',
+      );
     });
   });
 }


### PR DESCRIPTION
Added `CssBackgroundClip` sealed class implementing `CssValue` with support for keywords (`border-box`, `padding-box`, `content-box`, `text`) and multiple values. Added corresponding unit tests.

---
*PR created automatically by Jules for task [14585509314386071625](https://jules.google.com/task/14585509314386071625) started by @kevin-sakemaer*